### PR TITLE
Hotfix/timers conflict

### DIFF
--- a/src/soft_timer.c
+++ b/src/soft_timer.c
@@ -325,6 +325,10 @@ void timer_step(soft_timer_t* timer, uint16_t time_step_ms) {
         return;
     }
 
+    if ((timer->countdown_ms == 0) && (time_step_ms != 0)) {
+        return;
+    }
+
     timer->countdown_ms -= time_step_ms;
 
     if (timer->countdown_ms != 0) {

--- a/src/soft_timer.c
+++ b/src/soft_timer.c
@@ -321,16 +321,11 @@ void timer_stop(soft_timer_t* timer) {
 }
 
 void timer_step(soft_timer_t* timer, uint16_t time_step_ms) {
-    if (timer->state != TIMER_STATE_RUNNING) {
+    if ((timer->state != TIMER_STATE_RUNNING) || (timer->countdown_ms == 0)) {
         return;
     }
 
-    if ((timer->countdown_ms == 0) && (time_step_ms != 0)) {
-        return;
-    }
-
-    timer->countdown_ms = max(timer->countdown_ms, time_step_ms);
-    timer->countdown_ms -= time_step_ms;
+    timer->countdown_ms -= min(timer->countdown_ms, time_step_ms);
 
     if (timer->countdown_ms != 0) {
         return;

--- a/src/soft_timer.c
+++ b/src/soft_timer.c
@@ -329,6 +329,7 @@ void timer_step(soft_timer_t* timer, uint16_t time_step_ms) {
         return;
     }
 
+    timer->countdown_ms = max(timer->countdown_ms, time_step_ms);
     timer->countdown_ms -= time_step_ms;
 
     if (timer->countdown_ms != 0) {


### PR DESCRIPTION
Essa PR surgiu depois de tentar fazer o LED de uma placa piscar conforme a tensão da bateria no ThunderVolt, de forma que seriam utilizador dois timers ao mesmo tempo, um pra realizar a medição da bateria, a cada 10s, e um pra fazer o LED piscar, com período variável e definido dentro do callback do timer de medição da bateria. Com isso, dois problemas ocorreram:

O primeiro foi que com funções da lib sendo chamadas dentro do callback do timer de medição, como soft_timer_start e soft_timer_update, o timer responsável pelo callback ainda estava com seu countdown em 0, de forma que a função de step fez o countdown dar underflow e virar um valor gigante.

Outro problema que ocorreu foi que o valor de um timer era alterado durante a execução do código, com outro timer rodando em paralelo, de forma que poderia ocorrer de uma função de step ser chamada com um time_step maior do que o countdown do timer, resultando novamente em um underflow, que faz o countdown ir para o valor máximo.

Ambos os problemas foram tratados na função timer_step, que não sei se seria o lugar ideal para mexer, já que não conheço muito a lib, mas que resolveu o problema nos casos que citei

