### PR TITLE
Adiciona CMake 

### DIFF
--- a/cmake/FindSoftTimer.cmake
+++ b/cmake/FindSoftTimer.cmake
@@ -1,0 +1,11 @@
+set(SOFT_TIMER_PATH
+    ./lib/STM32SoftTimer
+)
+
+list(APPEND LIB_SOURCES
+    ${SOFT_TIMER_PATH}/src/soft_timer.c
+)
+
+list(APPEND LIB_INCLUDE_DIRECTORIES
+    ${SOFT_TIMER_PATH}/inc
+)

--- a/sources.mk
+++ b/sources.mk
@@ -1,8 +1,0 @@
-THIS_PATH := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-
-C_INCLUDES +=                                                          \
-	-I$(THIS_PATH)/inc
-
-LIB_SOURCES += $(shell find $(THIS_PATH)/src -name "*.c")
-
-undefine THIS_PATH


### PR DESCRIPTION
Essa PR adiciona CMake à lib.

O arquivo `cmake/FindSoftTimer.cmake` é achado por meio dos projetos (essa PR do Tracer [aqui](https://github.com/ThundeRatz/Tracer/pull/68)). Ele só serve para incluir os `.c` e os diretórios de `include` dentro das variáveis certas, do mesmo jeito que o arquivo `.mk` fazia antes