### PR TITLE
Feature Prescaler Adjust

### DIFF
--- a/inc/soft_timer.h
+++ b/inc/soft_timer.h
@@ -85,8 +85,10 @@ void soft_timer_destroy(soft_timer_t** timer);
 /**
  * @brief Configures timer.
  *
- * @note This function will configure a timer instance that is stopped.
+ * @note - This function will configure a timer instance that is stopped.
  *       Only configured timers may be started.
+ * @note - The reload value must be at least 2 and at most the maximum
+ *       value recalculated deppending on the timer frequency.
  *
  * @param timer     Pointer to timer instance to be configured.
  * @param callback  Pointer to timeout callback function.

--- a/src/soft_timer.c
+++ b/src/soft_timer.c
@@ -431,13 +431,8 @@ TIM_TypeDef* hard_timer_get_instance(TIM_HandleTypeDef* htim) {
 }
 
 void presc_adjust(uint32_t hclk_frequency, uint32_t* prescaler) {
-    bool max_div_found = false;
-
-    for (uint32_t i = 0xFFFF; !max_div_found; i--) {
-        uint32_t resto = hclk_frequency % i;
-        max_div_found = (hclk_frequency % i) == 0 ? true : false;
-
-        if (max_div_found) {
+    for (uint32_t i = 0xFFFF; (hclk_frequency % i) == 0; i--) {
+        if ((hclk_frequency % i) == 0) {
             (*prescaler) = i - 1;
             m_reload_adjust = (float) hclk_frequency / (i * 1000);
             m_max_reload_ms /= m_reload_adjust;


### PR DESCRIPTION
Recentemente estava trabalhando com um micro com uma clock base de 150 MHz e meus soft tims estavam todos dessincronizados. Ao debugar achei o problema em como o hard tim era iniciado:

![image](https://github.com/user-attachments/assets/2d972a90-9cdd-4ffc-a5b2-b246955151cd)

essa conta me retornava um prescaler de 149999. Isso quebrava meu código já que o valor máximo aceito pelo HAL é 65535 (uint16). Para corrigir isso eu criei uma função que ajusta o prescaler e altera algumas variáveis privadas no .c (`m_max_reload_ms` e `m_reload_adjust`) que me ajudam a setar a frequência certa dos soft tims.